### PR TITLE
Added generic data table component

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+sudo: required
+dist: trusty
+language: node_js
+node_js:
+  - '6'
+
+addons:
+apt:
+  sources:
+    - google-chrome
+  packages:
+    - google-chrome-stable
+    - google-chrome-beta
+
+before_install:
+  - export CHROME_BIN=chromium-browser
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
+
+before_script:
+- npm install -g angular-cli
+- npm install -g karma
+- npm install
+- ng build
+
+script: karma start config/karma.conf.js --single-run

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ apt:
     - google-chrome-beta
 
 before_install:
+  - cd herald
   - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,4 @@ before_script:
 - npm install
 - ng build
 
-script: karma start config/karma.conf.js --single-run
+#script: karma start config/karma.conf.js --single-run

--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # uthgard-herald
+
+[![Build Status](https://travis-ci.org/thekroko/uthgard-herald.png?branch=master)](https://travis-ci.org/thekroko/uthgard-herald)
+
+[Docker Status](https://hub.docker.com/r/uthgard/herald/builds/)
+

--- a/README.md
+++ b/README.md
@@ -4,3 +4,5 @@
 
 [Docker Status](https://hub.docker.com/r/uthgard/herald/builds/)
 
+Community implemented Herald for the Uthgard server. Git repository is automatically deployed to https://herald.uthgard.org once per hour.
+

--- a/herald/angular-cli.json
+++ b/herald/angular-cli.json
@@ -32,12 +32,12 @@
   "packages": [],
   "e2e": {
     "protractor": {
-      "config": "config/protractor.conf.js"
+      "config": "protractor.conf.js"
     }
   },
   "test": {
     "karma": {
-      "config": "config/karma.conf.js"
+      "config": "karma.conf.js"
     }
   },
   "defaults": {

--- a/herald/package.json
+++ b/herald/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "angular-cli": {},
   "scripts": {
-    "start": "./node_modules/.bin/ng serve",
+    "start": "./node_modules/.bin/ng serve --proxy-config proxy.config.json",
     "lint": "./node_modules/.bin/tslint \"src/**/*.ts\"",
     "test": "./node_modules/.bin/ng test",
     "build": "./generate-guild-data.js; ./generate-player-data.js; ./node_modules/.bin/ng build",

--- a/herald/proxy.config.json
+++ b/herald/proxy.config.json
@@ -1,0 +1,8 @@
+{
+        "/herald/api/*": {
+                "target": "https://uthgard.org/",
+                "changeOrigin": true,
+                "logLevel": "debug",
+                "secure": false
+        }
+}

--- a/herald/src/app/+character-profile/shared/character-profile.model.ts
+++ b/herald/src/app/+character-profile/shared/character-profile.model.ts
@@ -13,43 +13,44 @@ export class CharacterProfile {
               public xpPercent: number,
               public realmRankDecimal: number,
               public realmRankPercent: number,
-              public realmLevelPercent: number,
-              public guildEmblemId: number,
-              public relicsCaptured: number,
-              public keepsCaptured: number,
-              public keepBossesKilled: number,
-              public killDeathRatio: number,
-              public soloKillRatio: number,
-              public tradeskills: Tradeskill[],
-              public rvrStats: RvrKillStats,
-              public pveKills: PveKill[],
+              public realmLevelPercent: number = 0,
+              public guildEmblemId: number = 0,
+              public relicsCaptured: number = 0,
+              public keepsCaptured: number = 0,
+              public keepBossesKilled: number = 0,
+              public killDeathRatio: number = 0,
+              public soloKillRatio: number = 0,
+              public tradeskills: Tradeskill[] = [],
+              public rvrStats: RvrKillStats = new RvrKillStats(),
+              public pveKills: PveKill[] = [],
               /**
                * specific array order: Briton, Saracen, Highlander, Avalonian, Inconnu
                */
-              public albRaceKills: number[],
+              public albRaceKills: number[] = [0, 0, 0, 0, 0,],
               /**
                * specific array order: Celt, Lurikeen, Firbolg, Elf, Sylvan
                */
-              public hibRaceKills: number[],
+              public hibRaceKills: number[] = [0, 0, 0, 0, 0],
               /**
                * specific array order: Norse, Kobold, Troll, Dwarf, Valkyn
                */
-              public midRaceKills: number[],
+              public midRaceKills: number[] = [0, 0, 0, 0, 0],
               /**
                * specific array order: Armsman, Cabalist, Cleric, Friar, Infiltrator,
                * Mercenary, Minstrel, Necromancer, Paladin, Reaver, Scout, Sorcerer, Theurgist, Wizard
                */
-              public albClassKills: number[],
+              public albClassKills: number[] = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
               /**
                * specific array order: Berserker, Bonedancer, Healer, Hunter, Runemaster,
                * Savage, Shadowblade, Shaman, Skald, Spiritmaster, Thane, Warrior
                */
-              public hibClassKills: number[],
+              public hibClassKills: number[] = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
               /**
                * specific array order: Animist, Bard, Blademaster, Champion, Druid, Eldritch,
                * Enchanter, Hero, Mentalist, Nightshade, Ranger, Valewalker, Warden
                */
-              public midClassKills: number[]) {
+              public midClassKills: number[] = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]) {
+     this.rvrStats = rvrStats||new RvrKillStats();
   };
 
 

--- a/herald/src/app/+character-profile/shared/character-profile.service.ts
+++ b/herald/src/app/+character-profile/shared/character-profile.service.ts
@@ -1,9 +1,21 @@
-import {Injectable} from '@angular/core';
+import {Injectable, isDevMode} from '@angular/core';
+import {Http, Response} from '@angular/http';
 import {CharacterProfile} from './character-profile.model';
+import {Realm} from '../../shared/realm.enum';
 import {mockPlayerProfiles} from './mock-character-profiles';
+import {Observable} from 'rxjs/Rx';
 
 @Injectable()
 export class CharacterProfileService {
+  
+  private USE_MOCK_DATA = false;
+  private API_URL = 'https://uthgard.org/herald/api/players';
+
+  constructor(private http: Http){
+    if (isDevMode()) {
+      this.API_URL = '/herald/api/player/';
+    }
+  }
 
   /**
    * Gets the CharacterProfile of a character
@@ -13,8 +25,15 @@ export class CharacterProfileService {
   getPlayer(name: string): Promise<CharacterProfile> {
     //todo handle name case normalizing
     //todo hook into real API once it exists
-    return this.getPlayerFromMockDataWithDelay(name, 100);
-    //return this.getPlayerFromMockData(id);
+    if (this.USE_MOCK_DATA) {
+      return this.getPlayerFromMockDataWithDelay(name, 100);
+    } else {
+      var observable = this.getPlayerFromAPI(name);
+      return new Promise<CharacterProfile>((resolve, reject) => {
+        observable.subscribe(profile => resolve(profile),
+                             error => reject(error));
+      });
+    }
   }
 
   /*
@@ -49,4 +68,40 @@ export class CharacterProfileService {
       resolve(this.getPlayerFromMockData(name)), delayMS));
   }
 
+  /**
+   * Retrieves a player from the uthgard herald API
+   * @param name The character's name to look up
+   * @returns {Promise<CharacterProfile>}
+   */
+  private getPlayerFromAPI(name: string): Observable<CharacterProfile> {
+    const request = this.http.get(this.API_URL + name);
+    return request.map((response: Response) => this.getPlayerFromAPIResponse(response))
+           .catch((error: any) => Observable.throw(error));
+  }
+
+  /**
+   * Construct a CharacterProfile from the API response
+   * @param response The {Response} object of the API call
+   * @returns {CharacterProfile}
+   */
+  private getPlayerFromAPIResponse(response: Response): CharacterProfile {
+    const json = response.json(), raw = json.Raw;
+    const realm : Realm = {
+      1: Realm.Albion,
+      2: Realm.Midgard,
+      3: Realm.Hibernia
+    }[raw.Realm];
+    const profile = new CharacterProfile(
+      <string>json.FullName,
+      <string>json.ClassName,
+      <string>json.RaceName,
+      realm,
+      <string>raw.GuildName,
+      <number>json.Level,
+      <number>json.XP_Percent,
+      <number>json.RealmRank,
+      <number>json.RP_Percent,
+    );
+    return profile;
+  }
 }

--- a/herald/src/app/+character-profile/shared/rvr-kill-stats.model.ts
+++ b/herald/src/app/+character-profile/shared/rvr-kill-stats.model.ts
@@ -2,15 +2,15 @@
  * Class to hold the RvR kill statistics of a character
  */
 export class RvrKillStats {
-  constructor(public albKills: number,
-              public hibKills: number,
-              public midKills: number,
-              public deathblows: number,
-              public soloKills: number,
-              public killedMostNumKills: number,
-              public killedMostName: string,
-              public killedByMostNumKills: number,
-              public killedByMostName: string) {
+  constructor(public albKills: number = 0,
+              public hibKills: number = 0,
+              public midKills: number = 0,
+              public deathblows: number = 0,
+              public soloKills: number = 0,
+              public killedMostNumKills: number = 0,
+              public killedMostName: string = '',
+              public killedByMostNumKills: number = 0,
+              public killedByMostName: string = '') {
   };
 
   /**

--- a/herald/src/app/+guild-profile/guild-profile.component.html
+++ b/herald/src/app/+guild-profile/guild-profile.component.html
@@ -21,8 +21,8 @@
     </div>
   </div>
 
-  <div id="general-items">
-    <div class="table-wrapper">
+  <div class="row" id="general-items">
+    <div class="col-sm-12 col-md-6 table-wrapper">
         <data-table [hiddenColumns]="playerTableHiddenColumns" [headerConversions]="playerTableHeaders" [dataListener]="tableDataSubject" (headerClickEmitter)="handlePlayerTableHeaderClick($event)"></data-table> 
     </div>
   </div>

--- a/herald/src/app/+guild-profile/guild-profile.component.html
+++ b/herald/src/app/+guild-profile/guild-profile.component.html
@@ -22,6 +22,9 @@
   </div>
 
   <div id="general-items">
+    <div class="table-wrapper">
+        <data-table [dataListener]="tableDataSubject"></data-table> 
+    </div>
   </div>
 
 

--- a/herald/src/app/+guild-profile/guild-profile.component.html
+++ b/herald/src/app/+guild-profile/guild-profile.component.html
@@ -23,7 +23,7 @@
 
   <div id="general-items">
     <div class="table-wrapper">
-        <data-table [dataListener]="tableDataSubject" (headerClickEmitter)="handlePlayerTableHeaderClick($event)"></data-table> 
+        <data-table [hiddenColumns]="playerTableHiddenColumns" [headerConversions]="playerTableHeaders" [dataListener]="tableDataSubject" (headerClickEmitter)="handlePlayerTableHeaderClick($event)"></data-table> 
     </div>
   </div>
 

--- a/herald/src/app/+guild-profile/guild-profile.component.html
+++ b/herald/src/app/+guild-profile/guild-profile.component.html
@@ -23,7 +23,7 @@
 
   <div id="general-items">
     <div class="table-wrapper">
-        <data-table [dataListener]="tableDataSubject"></data-table> 
+        <data-table [dataListener]="tableDataSubject" (headerClickEmitter)="handlePlayerTableHeaderClick($event)"></data-table> 
     </div>
   </div>
 

--- a/herald/src/app/+guild-profile/guild-profile.component.ts
+++ b/herald/src/app/+guild-profile/guild-profile.component.ts
@@ -30,6 +30,13 @@ export class GuildProfileComponent implements OnInit{
               private http: Http) {
   }
 
+  handlePlayerTableHeaderClick(headerText: string){
+    this.playerDataStore.sortPlayersForValue(headerText)
+        .then((sortedPlayerData) => {
+           this.tableDataSubject.next(sortedPlayerData); 
+        });
+  }    
+
   ngOnInit(){
     this.sub = this.route.params.subscribe(params => {
     this.guildProfileService.getGuildProfile(params['name'])

--- a/herald/src/app/+guild-profile/guild-profile.component.ts
+++ b/herald/src/app/+guild-profile/guild-profile.component.ts
@@ -23,6 +23,19 @@ export class GuildProfileComponent implements OnInit{
 
   tableDataSubject: Subject<any> = new Subject<any>();
   currentSortColumn: string = '';
+  playerTableHeaders: {keyName: string, displayName: string}[] = [
+    {keyName: "fullName", displayName: "Name"},
+    {keyName: "raceName", displayName: "Race"},
+    {keyName: "className", displayName: "Class"},
+    {keyName: "level", displayName: "Level"},
+    {keyName: "realmRank", displayName: "Realm Rank"},
+  ];
+
+  playerTableHiddenColumns: string[] = [
+    'realm',
+    'rpPercent',
+    'xpPercent',
+  ];
 
   playerDataStore: PlayerDataStore = new PlayerDataStore(this.http);  
 

--- a/herald/src/app/+guild-profile/guild-profile.component.ts
+++ b/herald/src/app/+guild-profile/guild-profile.component.ts
@@ -1,6 +1,7 @@
 import {Component,OnInit} from '@angular/core';
 
 import {ActivatedRoute} from '@angular/router';
+import {Subject} from 'rxjs/Rx';
 import {ISubscription} from 'rxjs/Subscription';
 
 import {Http} from '@angular/http';
@@ -20,6 +21,8 @@ export class GuildProfileComponent implements OnInit{
   guild: GuildProfile;
   error: string;
 
+  tableDataSubject: Subject<any> = new Subject<any>();
+
   playerDataStore: PlayerDataStore = new PlayerDataStore(this.http);  
 
   constructor(private route: ActivatedRoute,
@@ -32,10 +35,25 @@ export class GuildProfileComponent implements OnInit{
     this.guildProfileService.getGuildProfile(params['name'])
         .subscribe((guildProfile: GuildProfile) => {
                 this.guild = guildProfile;
+
                 this.playerDataStore.addPlayers(this.guild.players);
+
+                this.playerDataStore.sortPlayersForValue('raceName')
+                    .then((data) => {
+                        this.tableDataSubject.next(data);
+                    },
+                    (err) => {
+                        console.dir(err);
+                    })
             },(error) => {
                 this.error = error;
             });
+    });
+    
+    //this is just to test data listening
+    this.tableDataSubject.subscribe(data => {
+        console.log("noticed tableDataSubject on parent");
+        console.log(data);
     });
   }
 }

--- a/herald/src/app/+guild-profile/guild-profile.component.ts
+++ b/herald/src/app/+guild-profile/guild-profile.component.ts
@@ -22,6 +22,7 @@ export class GuildProfileComponent implements OnInit{
   error: string;
 
   tableDataSubject: Subject<any> = new Subject<any>();
+  currentSortColumn: string = '';
 
   playerDataStore: PlayerDataStore = new PlayerDataStore(this.http);  
 
@@ -30,12 +31,6 @@ export class GuildProfileComponent implements OnInit{
               private http: Http) {
   }
 
-  handlePlayerTableHeaderClick(headerText: string){
-    this.playerDataStore.sortPlayersForValue(headerText)
-        .then((sortedPlayerData) => {
-           this.tableDataSubject.next(sortedPlayerData); 
-        });
-  }    
 
   ngOnInit(){
     this.sub = this.route.params.subscribe(params => {
@@ -62,5 +57,22 @@ export class GuildProfileComponent implements OnInit{
         console.log("noticed tableDataSubject on parent");
         console.log(data);
     });
+  }
+
+  handlePlayerTableHeaderClick(headerText: string){
+    this.playerDataStore.sortPlayersForValue(headerText)
+        .then((sortedPlayerData: any[]) => {
+            this.setSortColumn(headerText); 
+            
+            if (this.currentSortColumn[0] === '-'){sortedPlayerData.reverse()};
+
+            this.tableDataSubject.next(sortedPlayerData); 
+        });
+  }    
+
+  //sets the sort column based on the data passed in and the current sort column
+  setSortColumn(headerText: string){
+    //-before indicates descending sort
+    this.currentSortColumn = headerText === this.currentSortColumn ? `-${headerText}` : headerText;
   }
 }

--- a/herald/src/app/+guild-profile/guild-profile.component.ts
+++ b/herald/src/app/+guild-profile/guild-profile.component.ts
@@ -20,14 +20,15 @@ import {SmallPlayerData} from '../shared/player-data/small-player-data';
 })
 export class GuildProfileComponent implements OnInit{
   sub: ISubscription;
-  guild: GuildProfile;
-  error: string;
+  guild: GuildProfile; //the guild which should be displayed
+  error: string; //whether there is an error
 
-  tableDataSubject: Subject<any> = new Subject<any>();
-  currentSortColumn: string = '';
-  currentIterator: number = 0;
-  pageSize: number = 5;
+  tableDataSubject: Subject<any> = new Subject<any>(); //to provide data to the player table
+  currentSortColumn: string = ''; //which column of the table is currently sorted
+  currentIterator: number = 0; //the index at which player data starts
+  pageSize: number = 5; //the amount of players to be displayed per page of hte guild profile
 
+  //used to convert keys of player data to display names
   playerTableHeaders: {keyName: string, displayName: string}[] = [
     {keyName: "fullName", displayName: "Name"},
     {keyName: "raceName", displayName: "Race"},
@@ -36,12 +37,14 @@ export class GuildProfileComponent implements OnInit{
     {keyName: "realmRank", displayName: "Realm Rank"},
   ];
 
+  //which columns of the player data are hidden
   playerTableHiddenColumns: string[] = [
     'realm',
     'rpPercent',
     'xpPercent',
   ];
 
+  //used to store, sort, and retrieve player data
   playerDataStore: PlayerDataStore = new PlayerDataStore(this.http);  
 
   constructor(private route: ActivatedRoute,
@@ -58,20 +61,19 @@ export class GuildProfileComponent implements OnInit{
 
                 this.playerDataStore.addPlayers(this.guild.players);
                 this.playerDataStore.getPlayerRange(this.currentIterator,this.currentIterator+this.pageSize)
-                    .then((data) => {this.tableDataSubject.next(data)})
+                    .then((data) => {this.tableDataSubject.next(data); console.dir(this.playerDataStore.playerData)})
 
             },(error) => {
                 this.error = error;
             });
     });
-    
-    //this is just to test data listening
-    this.tableDataSubject.subscribe(data => {
-        console.log("noticed tableDataSubject on parent");
-        console.log(data);
-    });
   }
 
+  /**
+  * responds to a click on a player table header, in this case by sending
+  * sorted data to the player table
+  * @param headerText the header of the column clicked
+  */
   handlePlayerTableHeaderClick(headerText: string){
     this.playerDataStore.sortPlayersForValue(headerText)
         .then(() => {
@@ -83,13 +85,17 @@ export class GuildProfileComponent implements OnInit{
                 .then((returnedPlayerData: SmallPlayerData[]) => {
                     if (this.currentSortColumn[0] === '-'){returnedPlayerData.reverse()};//TODO: reverse needs to be done at player data store level
                     this.tableDataSubject.next(returnedPlayerData); 
+                    console.dir(this.playerDataStore.playerData);
                 })
         });
   }    
 
-  //sets the sort column based on the data passed in and the current sort column
+  /**
+  * sets the sort column based on the data passed in and the current sort column
+  * @param headerText the headerText which was clicked
+  */
   setSortColumn(headerText: string){
     //-before indicates descending sort
-    this.currentSortColumn = headerText === this.currentSortColumn ? `-${headerText}` : headerText;
+    this.currentSortColumn = headerText === this.currentSortColumn ? `-${headerText}` : headerText; //sets to reversed sort if the column sort is the same
   }
 }

--- a/herald/src/app/app.module.ts
+++ b/herald/src/app/app.module.ts
@@ -9,6 +9,7 @@ import {CharacterProfileComponent, ProgressComponent, PveKillsComponent, RaceCla
 } from './+character-profile';
 import {GuildProfileComponent} from './+guild-profile/guild-profile.component';
 import {CharacterProfileService} from './+character-profile';
+import {DataTableComponent} from './shared/data-table/data-table.component';
 import {GuildProfileService} from './+guild-profile/shared/guild-profile.service';
 import {HomeComponent} from './+home';
 
@@ -26,6 +27,7 @@ import {HomeComponent} from './+home';
     SiegeStatsComponent,
     TradeskillsComponent,
     GuildProfileComponent,
+    DataTableComponent,
   ],
   bootstrap: [AppComponent],     // root component
   providers: [CharacterProfileService,// services

--- a/herald/src/app/shared/data-table/data-table.component.css
+++ b/herald/src/app/shared/data-table/data-table.component.css
@@ -1,0 +1,3 @@
+thead{
+    background-color: #a90414;
+}

--- a/herald/src/app/shared/data-table/data-table.component.html
+++ b/herald/src/app/shared/data-table/data-table.component.html
@@ -1,7 +1,7 @@
 <div class="data-table-inner">
     <table class="data-table">
         <tr class="data-table-header">
-            <td *ngFor="let data of currentCols">{{ data }}</td> 
+            <td *ngFor="let data of currentCols" (click)="headerClick(data)">{{ data }}</td> 
         </tr>
         <tr *ngFor="let data of currentData" class="data-table-row">
             <td *ngFor="let key of currentCols">{{ data[key] }}</td> 

--- a/herald/src/app/shared/data-table/data-table.component.html
+++ b/herald/src/app/shared/data-table/data-table.component.html
@@ -1,10 +1,14 @@
 <div class="data-table-inner">
     <table class="data-table">
         <tr class="data-table-header">
-            <td *ngFor="let data of currentCols" (click)="headerClick(data)">{{ data }}</td> 
+            <ng-container *ngFor="let data of currentCols">
+                <td *ngIf="!columnIsHidden(data)" (click)="headerClick(data)">{{ convertHeader(data) }}</td> 
+            </ng-container>
         </tr>
         <tr *ngFor="let data of currentData" class="data-table-row">
-            <td *ngFor="let key of currentCols">{{ data[key] }}</td> 
+            <ng-container *ngFor="let key of currentCols">
+                <td *ngIf="!columnIsHidden(key)">{{ data[key] }}</td> 
+            </ng-container>
         </tr>
     </table>
 </div>

--- a/herald/src/app/shared/data-table/data-table.component.html
+++ b/herald/src/app/shared/data-table/data-table.component.html
@@ -1,0 +1,10 @@
+<div class="data-table-inner">
+    <table class="data-table">
+        <tr class="data-table-header">
+            <td *ngFor="let data of currentCols">{{ data }}</td> 
+        </tr>
+        <tr *ngFor="let data of currentData" class="data-table-row">
+            <td *ngFor="let key of currentCols">{{ data[key] }}</td> 
+        </tr>
+    </table>
+</div>

--- a/herald/src/app/shared/data-table/data-table.component.html
+++ b/herald/src/app/shared/data-table/data-table.component.html
@@ -1,14 +1,18 @@
 <div class="data-table-inner">
-    <table class="data-table">
+    <table class="table">
+      <thead>
         <tr class="data-table-header">
             <ng-container *ngFor="let data of currentCols">
-                <td *ngIf="!columnIsHidden(data)" (click)="headerClick(data)">{{ convertHeader(data) }}</td> 
+                <th *ngIf="!columnIsHidden(data)" (click)="headerClick(data)">{{ convertHeader(data) }}</th> 
             </ng-container>
         </tr>
+      </thead>
+      <tbody>
         <tr *ngFor="let data of currentData" class="data-table-row">
             <ng-container *ngFor="let key of currentCols">
                 <td *ngIf="!columnIsHidden(key)">{{ data[key] }}</td> 
             </ng-container>
         </tr>
+      </tbody>
     </table>
 </div>

--- a/herald/src/app/shared/data-table/data-table.component.ts
+++ b/herald/src/app/shared/data-table/data-table.component.ts
@@ -6,51 +6,71 @@ import {Subject} from 'rxjs/Subject';
 @Component({
     templateUrl: './data-table.component.html',
     selector: 'data-table',
+    styleUrls: ['./data-table.component.css'],
 })
 export class DataTableComponent implements OnInit{
     @Input()
-    dataListener: Subject<any>;
+    dataListener: Subject<any>; //listens for data coming in
 
     @Input()
-    headerConversions: {keyName: string, displayName: string}[];
+    headerConversions: {keyName: string, displayName: string}[]; //converts the format of headers
 
     @Input()
-    hiddenColumns: string[];
+    hiddenColumns: string[]; //used to hide particular columns
 
     @Output()
-    headerClickEmitter: EventEmitter<string> = new EventEmitter<string>();
+    headerClickEmitter: EventEmitter<string> = new EventEmitter<string>(); //sends events when headers are clicked
 
-    currentData: any[] = [];
-    currentCols: string[] = [];
+    currentData: any[] = []; //current data is an array of objects
+    currentCols: string[] = []; //used to store the keys against which columns can be formed
 
     ngOnInit(){
         this.dataListener.subscribe((data) => {
-            console.log('heard some data on child component');
-            console.dir(data);
             this.updateData(data);
         });
     }
 
+    /**
+    * converts a header between the key name and it's display name, if there is one
+    * @param headerKey the key of the header to be converted
+    * @returns         the converted key, or the original, if there was no match
+    */
     convertHeader(headerKey: string){
         let matchObject = this.headerConversions.find((element) => {return element.keyName === headerKey}) || {displayName: headerKey};
         return matchObject.displayName;
     }
 
+    /**
+    * checks whether or not the column is hidden
+    * @param keyName the key of the header to be checked
+    * @returns       whether or not the column is hidden
+    */
     columnIsHidden(keyName: string): boolean{
         let foundKey =  this.hiddenColumns.indexOf(keyName);
         return foundKey !== -1;
     }
 
+    /**
+    * provides a function which will emit an event for a header click
+    * @param headerText the text of the header which was clicked
+    */
     headerClick(headerText: string){
-        console.log(`header ${headerText} clicked`);
         this.headerClickEmitter.emit(headerText);
     }
     
+    /**
+    * sets the currentData to the data provided, and creates the relevant columns for that data
+    * @param data should be an array of objects
+    */ 
     updateData(data: any[]){
         this.currentData = data;
         this.currentCols = this.getColumnsFromData(data);
     }
 
+    /**
+    * sets the columns from the data provided
+    * @param data should be an array of objects
+    */
     getColumnsFromData(data: any[]){
         let validKeys = {};
         for (let i = 0; i < data.length; i++){
@@ -59,9 +79,6 @@ export class DataTableComponent implements OnInit{
                 validKeys[key] = true;
             }  
         }
-        console.log(validKeys);
-        console.log('keys:');
-        console.log(Object.keys(validKeys));
         return Object.keys(validKeys); 
     }
 }

--- a/herald/src/app/shared/data-table/data-table.component.ts
+++ b/herald/src/app/shared/data-table/data-table.component.ts
@@ -11,6 +11,12 @@ export class DataTableComponent implements OnInit{
     @Input()
     dataListener: Subject<any>;
 
+    @Input()
+    headerConversions: {keyName: string, displayName: string}[];
+
+    @Input()
+    hiddenColumns: string[];
+
     @Output()
     headerClickEmitter: EventEmitter<string> = new EventEmitter<string>();
 
@@ -23,6 +29,16 @@ export class DataTableComponent implements OnInit{
             console.dir(data);
             this.updateData(data);
         });
+    }
+
+    convertHeader(headerKey: string){
+        let matchObject = this.headerConversions.find((element) => {return element.keyName === headerKey}) || {displayName: headerKey};
+        return matchObject.displayName;
+    }
+
+    columnIsHidden(keyName: string): boolean{
+        let foundKey =  this.hiddenColumns.indexOf(keyName);
+        return foundKey !== -1;
     }
 
     headerClick(headerText: string){
@@ -48,6 +64,4 @@ export class DataTableComponent implements OnInit{
         console.log(Object.keys(validKeys));
         return Object.keys(validKeys); 
     }
-
-    
 }

--- a/herald/src/app/shared/data-table/data-table.component.ts
+++ b/herald/src/app/shared/data-table/data-table.component.ts
@@ -1,0 +1,45 @@
+import {Component, OnInit, Input} from '@angular/core';
+//import {SmallPlayerData} from '../player-data/small-player-data';
+
+import {Subject} from 'rxjs/Subject';
+
+@Component({
+    templateUrl: './data-table.component.html',
+    selector: 'data-table',
+})
+export class DataTableComponent implements OnInit{
+    @Input()
+    dataListener: Subject<any>;
+
+    currentData: any[] = [];
+    currentCols: string[] = [];
+
+    ngOnInit(){
+        this.dataListener.subscribe((data) => {
+            console.log('heard some data on child component');
+            console.dir(data);
+            this.updateData(data);
+        });
+    }
+    
+    updateData(data: any[]){
+        this.currentData = data;
+        this.currentCols = this.getColumnsFromData(data);
+    }
+
+    getColumnsFromData(data: any[]){
+        let validKeys = {};
+        for (let i = 0; i < data.length; i++){
+            let thisDataItem = data[i];
+            for (let key in thisDataItem){
+                validKeys[key] = true;
+            }  
+        }
+        console.log(validKeys);
+        console.log('keys:');
+        console.log(Object.keys(validKeys));
+        return Object.keys(validKeys); 
+    }
+
+    
+}

--- a/herald/src/app/shared/data-table/data-table.component.ts
+++ b/herald/src/app/shared/data-table/data-table.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit, Input} from '@angular/core';
+import {Component, OnInit, Input, Output, EventEmitter} from '@angular/core';
 //import {SmallPlayerData} from '../player-data/small-player-data';
 
 import {Subject} from 'rxjs/Subject';
@@ -11,6 +11,9 @@ export class DataTableComponent implements OnInit{
     @Input()
     dataListener: Subject<any>;
 
+    @Output()
+    headerClickEmitter: EventEmitter<string> = new EventEmitter<string>();
+
     currentData: any[] = [];
     currentCols: string[] = [];
 
@@ -20,6 +23,11 @@ export class DataTableComponent implements OnInit{
             console.dir(data);
             this.updateData(data);
         });
+    }
+
+    headerClick(headerText: string){
+        console.log(`header ${headerText} clicked`);
+        this.headerClickEmitter.emit(headerText);
     }
     
     updateData(data: any[]){

--- a/herald/src/app/shared/player-data/player-data-store.component.ts
+++ b/herald/src/app/shared/player-data/player-data-store.component.ts
@@ -66,7 +66,7 @@ export class PlayerDataStore{
                             loadedCount++;
 
                             if (loadedCount >= this.playerNames['unsorted'].length){
-                                resolve(this.playerNames[valueKey]);
+                                resolve(this.namesToData(this.playerNames[valueKey]));
                             }
                         } else {
                             throw new Error(`Player cannot be sorted on ${valueKey}`);
@@ -75,6 +75,21 @@ export class PlayerDataStore{
                     }); 
             }    
         });
+    }
+    
+    /**
+    * converts a list of player names to the data held on them
+    * if no data is held, none will not be added
+    */
+    namesToData(names: string[]){
+        let playerData = [];
+        for (let i = 0; i < names.length; i++){
+            let playerCheckingData = this.playerData[names[i]];
+            if (playerCheckingData){
+                playerData.push(playerCheckingData);
+            }
+        }
+        return playerData;
     }
 
     //loads a player and adds it to the list of playerData

--- a/herald/src/app/shared/player-data/player-data-store.component.ts
+++ b/herald/src/app/shared/player-data/player-data-store.component.ts
@@ -14,13 +14,28 @@ export class PlayerDataStore{
     }
 
     //returns players from the current sort between the values specified
-    getPlayerRange(startIndex: number, endIndex: number){
-       let selectedPlayers = this.playerNames[this.currentColumnSort].slice(startIndex, endIndex); 
-       let returnData = [];
-       for (let i = 0; i < selectedPlayers.length; i++){
-            returnData.push(this.playerData[selectedPlayers[i]]);
-       }
-       return returnData;
+    getPlayerRange(startIndex: number, endIndex: number, reverse: boolean = false): Promise<SmallPlayerData[]>{
+        
+        let firstIndex = reverse ? this.playerNames[this.currentColumnSort].length - startIndex : startIndex;
+        let secondIndex = reverse ? this.playerNames[this.currentColumnSort].length - endIndex : endIndex;
+
+        let firstIndexTemp = firstIndex;
+        firstIndex = Math.min(firstIndexTemp, secondIndex);
+        secondIndex = Math.max(firstIndexTemp, secondIndex);    
+
+        let selectedPlayers = this.playerNames[this.currentColumnSort].slice(firstIndex, secondIndex); 
+
+        return new Promise((resolve) => {
+            let playerPromises: Promise<SmallPlayerData>[] = []; 
+            
+            for (let i = 0; i < selectedPlayers.length; i++){
+                 playerPromises.push(this.loadPlayer(selectedPlayers[i]));
+            }
+
+            Promise.all(playerPromises).then((loadedValues) => {
+                resolve(loadedValues);//TODO: sort before resolve
+            });
+        })
     }
     
     //adds a player name

--- a/herald/src/app/shared/player-data/player-data-store.component.ts
+++ b/herald/src/app/shared/player-data/player-data-store.component.ts
@@ -4,16 +4,27 @@ import {Observable} from 'rxjs/Observable';
 
 export class PlayerDataStore{
          
-    public playerData: SmallPlayerData[] = [];
+    public playerData: SmallPlayerData[] = []; //the data for the players, indexed against their names 
     public playerNames: string[] = []; //as column_name: [list of player names sorted by that] (including an unsorted)
-    public currentColumnSort: string = 'alpha'; //alphabetical as default sort
+    public currentColumnSort: string; //alphabetical as default sort
 
-    constructor(private http:Http){
+    /**
+    * @param http         the http service which will be used to fetch character data
+    * @param presumedSort the column which will be the presumed sort by default
+    */
+    constructor(private http:Http, presumedSort: string = 'alpha'){
         this.playerNames['unsorted'] = []; 
         this.playerNames['alpha'] = []; //to ensure we always have an alpha sorted list
+        this.currentColumnSort = presumedSort;
     }
 
-    //returns players from the current sort between the values specified
+    /**
+    * returns players data from the current sort between the values specified
+    * @param startIndex the index from which to start
+    * @param endIndex   the index at which to end
+    * @param reversed   do we want to work from the end of the list?
+    * @returns          a promise of an array of SmallPlayerData for the range specified 
+    */
     getPlayerRange(startIndex: number, endIndex: number, reverse: boolean = false): Promise<SmallPlayerData[]>{
         
         let firstIndex = reverse ? this.playerNames[this.currentColumnSort].length - startIndex : startIndex;
@@ -38,13 +49,19 @@ export class PlayerDataStore{
         })
     }
     
-    //adds a player name
+    /**
+    * adds a player name to the unsorted and alpha lists
+    * @param playerName the name to be added
+    */
     addPlayerName(playerName: string){
         this.playerNames['unsorted'].push(playerName);
         this.addPlayerNameToAlpha(playerName);
     }
 
-    //adds a player name to the list of alpha sorted player names
+    /**
+    * inserts the player name into the alpha list at the correct position
+    * @param playername the name to be added
+    */
     addPlayerNameToAlpha(playerName: string){
         var i;
         for (i=0; i<this.playerNames['alpha'].length && playerName > this.playerNames['alpha'][i]; i++){
@@ -52,14 +69,22 @@ export class PlayerDataStore{
         this.playerNames['alpha'].splice(Math.max(i, 0), 0, playerName);
     }
 
-    //adds a list of player names to the list of player names
+    /**
+    * adds a list of player names to the list of player names
+    * @param playerNames the list of names to be added
+    */
     addPlayers(playerNames: string[]){
         for (let i = 0; i < playerNames.length; i++){
             this.addPlayerName(playerNames[i]);
         } 
     }
     
-    //sets a sorted list of player names according the the value key provided
+    /** 
+    * sets a sorted list of player names according the the value key provided,
+    * and returns a promise with the sorted data
+    * @param valueKey the key of the property on which to sort
+    * @returns        a promise with the player data sorted on the key provided
+    */
     sortPlayersForValue(valueKey: string){
         return new Promise(resolve => {
             let sortedPlayers = [];
@@ -95,6 +120,8 @@ export class PlayerDataStore{
     /**
     * converts a list of player names to the data held on them
     * if no data is held, none will not be added
+    * @param names the list of player names for which data is needed
+    * @returns     the data for the players, where it was available
     */
     namesToData(names: string[]){
         let playerData = [];
@@ -107,7 +134,11 @@ export class PlayerDataStore{
         return playerData;
     }
 
-    //loads a player and adds it to the list of playerData
+    /**
+    * loads a player and adds it to the list of playerData
+    * @param playerName the name of the player to be added
+    * @returns          a promise with the data for the player
+    */
     loadPlayer(playerName: string){
         return new Promise(resolve => {
             if (this.playerData[playerName]){
@@ -124,6 +155,8 @@ export class PlayerDataStore{
 
     /**
     * returns an observable which outputs player data for the name given
+    * @param playerName the name of the player for which data is being reuqested
+    * @returns          an observable which will return the data for the player requested
     */
     getPlayerData(playerName): Observable<SmallPlayerData>{
       let playerUrl = `/assets/data/players/${playerName}.json`;


### PR DESCRIPTION
---
*edit to clarify:
The scope of this PR was originally to create _only_ the data table, which would be used to display data in tables. For my purposes this was mostly for the guild profile, but it's useful wherever we want to display things in tables (most pages).

This is closely tied, in the case of the guild profile, the the player-data-store. It works as such:

PlayerDataStore -> GuildProfile -> DataTable

The guild profile listens for events from the data table, and requests data from the player data store accordingly. After trying out other, more straightforward solutions previously, this one has been clearly the easiest to work with. 

Because these features are so closely tied together, it's difficult to work on them in isolation. When I first created the PR I was hoping it would be merged quickly so I could carry on working without adding in much further, but as I continue the work on the components it makes sense to merge them into this PR, as it;s all for the same thing.

There's some other commits in here from where I've been rebasing against master, I'm really no git expert, but none of these are causing any merge conflicts at all, so I'm unsure as to why this PR can't be approved. If it's just for the sake of commit history, it seems strange to me to prioritise commit history over progress on the project.
---

We'll presumably want to be able to display data in tables, for guild profiles, player rankings etc.

The data table component takes a subject which is used to send it data. It figures out the appropriate headers and displays the data. It has an output, currently only used for column headers, could eventually be used for next page etc. This is currently bound to redo the sorting, which now works for sorting both ways.

Not by any means finished, but after trying a few different ways of handling async player loading, this seems to be easiest for now